### PR TITLE
Change size_t to a fixed 64 type (uint64)

### DIFF
--- a/libraries/networking/message/AxonMessage.cpp
+++ b/libraries/networking/message/AxonMessage.cpp
@@ -5,7 +5,7 @@
 
 #pragma region AxonMessage
 
-Networking::AxonMessage::AxonMessage(void* message, size_t size, uint8_t partID, uint8_t flags)
+Networking::AxonMessage::AxonMessage(void* message, size64_t size, uint8_t partID, uint8_t flags)
 {
 	if (message == nullptr)
 		return;
@@ -23,7 +23,7 @@ Networking::AxonMessage::AxonMessage(void* message, size_t size, uint8_t partID,
     this->flags = flags;
 }
 
-Networking::AxonMessage::AxonMessage(const char* bits, size_t actualSize)
+Networking::AxonMessage::AxonMessage(const char* bits, size64_t actualSize)
 {
     TAG_T tag;
 
@@ -81,7 +81,7 @@ void Networking::AxonMessage::decompressTag(const TAG_T tag) {
     flags = tag & ((1UL << 9) - 1);
 }
 
-Networking::AxonMessage Networking::AxonMessage::split(const size_t sendSize) {
+Networking::AxonMessage Networking::AxonMessage::split(const size64_t sendSize) {
     if (sendSize >= size)
         throw 1;
     uintptr_t pMessage = reinterpret_cast<uintptr_t> (message);

--- a/libraries/networking/message/AxonMessage.hpp
+++ b/libraries/networking/message/AxonMessage.hpp
@@ -29,7 +29,7 @@ namespace Networking
 
     struct SerializedAxonMessage
     {
-        size_t size = 0;
+        size64_t size = 0;
         const char* bitstream = nullptr;
     };
 
@@ -50,7 +50,7 @@ namespace Networking
 		 *
 		 * @see Networking::SerializedAxonMessage
 		*/
-		AxonMessage(const char*, size_t);
+		AxonMessage(const char*, size64_t);
 
         /**
          * Create new message from serialized message structure (preferred)
@@ -62,7 +62,7 @@ namespace Networking
 
         SerializedAxonMessage getSerialized() const;
 		void* getMessage() const { return message; }
-		size_t getSize() const { return size; }
+		size64_t getSize() const { return size; }
         uint8_t getFlags() const { return flags; }
         uint8_t getPartID() const { return partID; }
 
@@ -71,12 +71,12 @@ namespace Networking
         void addFlag(TAG_FLAGS flag) { this->flags |= flag; }
         void removeFlag(TAG_FLAGS flag) { this->flags ^= flag; }
 
-        AxonMessage split(size_t);
+        AxonMessage split(size64_t);
     protected:
         static TAG_T generateTag(uint8_t, uint8_t);
         inline void decompressTag(TAG_T);
 	private:
-		size_t		size;
+		size64_t	size;
 		void*		message;
         uint8_t     partID = 0;
         uint8_t     flags = TAG_FLAGS::UNDEFINED;

--- a/libraries/networking/message/AxonMessage.hpp
+++ b/libraries/networking/message/AxonMessage.hpp
@@ -43,7 +43,7 @@ namespace Networking
 		/**
 		* Create new message from actual data (send mode)
 		*/
-		AxonMessage(void*, size_t, uint8_t = 0, uint8_t = 0);
+		AxonMessage(void*, size64_t, uint8_t = 0, uint8_t = 0);
 
 		/**
 		* Create new message from legacy serialized data (recv mode)

--- a/libraries/serialization/serialization.c
+++ b/libraries/serialization/serialization.c
@@ -2,11 +2,11 @@
 #include <string.h>
 
 
-char* serialize(const char* data, const size_t size, const TAG_T tag, size_t* totalSize)
+char* serialize(const char* data, const Size64 size, const TAG_T tag, Size64* totalSize)
 {
     *totalSize = 0;
-    size_t header_size = 0;
-    size_t footer_size = 0;
+    Size64 header_size = 0;
+    Size64 footer_size = 0;
 
     while (size >> header_size * 8)
         header_size += 1;
@@ -26,13 +26,13 @@ char* serialize(const char* data, const size_t size, const TAG_T tag, size_t* to
     return buffer;
 }
 
-uint8_t deserialize(const char* serialized, const size_t size, void** deserialized, size_t* actualSize, TAG_T* tag)
+uint8_t deserialize(const char* serialized, const Size64 size, void** deserialized, Size64* actualSize, TAG_T* tag)
 {
-    size_t actual = size;
-    size_t header_size = sizeof(actual);
+    Size64 actual = size;
+    Size64 header_size = sizeof(actual);
     do
     {
-        actual = (*(size_t*)(serialized));
+        actual = (*(Size64*)(serialized));
         actual &= (1ULL << --header_size * 8) - 1;
     } while (size < actual && header_size > 0);
 
@@ -42,7 +42,7 @@ uint8_t deserialize(const char* serialized, const size_t size, void** deserializ
 
     /* Shrink header size */
 
-    size_t shrunk = actual;
+    Size64 shrunk = actual;
     while (shrunk == actual != 0 && header_size > 0)
     {
         shrunk = actual & (1ULL << --header_size * 8) - 1;
@@ -60,7 +60,7 @@ uint8_t deserialize(const char* serialized, const size_t size, void** deserializ
         return 2;
     
     memcpy(*deserialized, serialized + header_size, actual);
-    const size_t footer_size = size - actual - header_size;
+    const Size64 footer_size = size - actual - header_size;
     
     *tag = (*(uint64_t*) (serialized + actual + header_size)) & ((1ULL << footer_size * 8) - 1);
     *actualSize = actual;

--- a/libraries/serialization/serialization.c
+++ b/libraries/serialization/serialization.c
@@ -2,11 +2,11 @@
 #include <string.h>
 
 
-char* serialize(const char* data, const Size64 size, const TAG_T tag, Size64* totalSize)
+char* serialize(const char* data, const size64_t size, const TAG_T tag, size64_t* totalSize)
 {
     *totalSize = 0;
-    Size64 header_size = 0;
-    Size64 footer_size = 0;
+    size64_t header_size = 0;
+    size64_t footer_size = 0;
 
     while (size >> header_size * 8)
         header_size += 1;
@@ -26,13 +26,13 @@ char* serialize(const char* data, const Size64 size, const TAG_T tag, Size64* to
     return buffer;
 }
 
-uint8_t deserialize(const char* serialized, const Size64 size, void** deserialized, Size64* actualSize, TAG_T* tag)
+uint8_t deserialize(const char* serialized, const size64_t size, void** deserialized, size64_t* actualSize, TAG_T* tag)
 {
-    Size64 actual = size;
-    Size64 header_size = sizeof(actual);
+    size64_t actual = size;
+    size64_t header_size = sizeof(actual);
     do
     {
-        actual = (*(Size64*)(serialized));
+        actual = (*(size64_t*)(serialized));
         actual &= (1ULL << --header_size * 8) - 1;
     } while (size < actual && header_size > 0);
 
@@ -42,7 +42,7 @@ uint8_t deserialize(const char* serialized, const Size64 size, void** deserializ
 
     /* Shrink header size */
 
-    Size64 shrunk = actual;
+    size64_t shrunk = actual;
     while (shrunk == actual != 0 && header_size > 0)
     {
         shrunk = actual & (1ULL << --header_size * 8) - 1;
@@ -60,7 +60,7 @@ uint8_t deserialize(const char* serialized, const Size64 size, void** deserializ
         return 2;
     
     memcpy(*deserialized, serialized + header_size, actual);
-    const Size64 footer_size = size - actual - header_size;
+    const size64_t footer_size = size - actual - header_size;
     
     *tag = (*(uint64_t*) (serialized + actual + header_size)) & ((1ULL << footer_size * 8) - 1);
     *actualSize = actual;

--- a/libraries/serialization/serialization.h
+++ b/libraries/serialization/serialization.h
@@ -8,6 +8,10 @@
 
 #define TAG_T uint16_t
 
+// Define alias for uint64_t to be used instead of size_t
+//  as size_t may have different size on different machines (i.e. x86 vs x64)
+typedef uint64_t Size64;
+
 /**
 * Creates serialized string from data given
 * 
@@ -17,7 +21,7 @@
 * @param[out] totalSize - will contain total serialized data size, bytes
 * @returns serialized message - pointer to char array
 */
-AXON_DECLSPEC char* serialize(const char* /* data */, size_t /* size */, TAG_T /* tag */, size_t* /* totalSize */);
+AXON_DECLSPEC char* serialize(const char* /* data */, Size64 /* size */, TAG_T /* tag */, Size64* /* totalSize */);
 
 /**
 * @param serialized - raw data
@@ -27,6 +31,6 @@ AXON_DECLSPEC char* serialize(const char* /* data */, size_t /* size */, TAG_T /
 * @param tag - will contain deserialized message footer
 * @returns 0 or error code
 */
-AXON_DECLSPEC uint8_t deserialize(const char* /* serialized */ , size_t /* size */, void** /* deserialized */, size_t* /* actualSize */, TAG_T* /* tag */);
+AXON_DECLSPEC uint8_t deserialize(const char* /* serialized */ , Size64 /* size */, void** /* deserialized */, Size64* /* actualSize */, TAG_T* /* tag */);
 
 #endif	// AXONENGINE_SERIALIZATION_H

--- a/libraries/serialization/serialization.h
+++ b/libraries/serialization/serialization.h
@@ -10,7 +10,7 @@
 
 // Define alias for uint64_t to be used instead of size_t
 //  as size_t may have different size on different machines (i.e. x86 vs x64)
-typedef uint64_t Size64;
+typedef uint64_t size64_t;
 
 /**
 * Creates serialized string from data given
@@ -21,7 +21,7 @@ typedef uint64_t Size64;
 * @param[out] totalSize - will contain total serialized data size, bytes
 * @returns serialized message - pointer to char array
 */
-AXON_DECLSPEC char* serialize(const char* /* data */, Size64 /* size */, TAG_T /* tag */, Size64* /* totalSize */);
+AXON_DECLSPEC char* serialize(const char* /* data */, size64_t /* size */, TAG_T /* tag */, size64_t* /* totalSize */);
 
 /**
 * @param serialized - raw data
@@ -31,6 +31,6 @@ AXON_DECLSPEC char* serialize(const char* /* data */, Size64 /* size */, TAG_T /
 * @param tag - will contain deserialized message footer
 * @returns 0 or error code
 */
-AXON_DECLSPEC uint8_t deserialize(const char* /* serialized */ , Size64 /* size */, void** /* deserialized */, Size64* /* actualSize */, TAG_T* /* tag */);
+AXON_DECLSPEC uint8_t deserialize(const char* /* serialized */ , size64_t /* size */, void** /* deserialized */, size64_t* /* actualSize */, TAG_T* /* tag */);
 
 #endif	// AXONENGINE_SERIALIZATION_H


### PR DESCRIPTION
In reference to issue #84, change "size_t" in serialisation to a fixed 64 bit unsigned type (Size64) to support cross platform communication.